### PR TITLE
[FIX] Missing swipeable_card_stack package in pubspec.yaml file

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -123,14 +123,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
-  scroll_snap_list:
-    dependency: "direct main"
-    description:
-      name: scroll_snap_list
-      sha256: "8009ad9030f680b93f3107b29b1ea31284d867aa4972868d2970c6d61fe9e59f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -208,14 +200,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  wheel_chooser:
-    dependency: "direct main"
-    description:
-      name: wheel_chooser
-      sha256: "3fee36f081f321c58a0b7b4afcdd92599f2ca520b3a1420084774e6b19cca1d8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
 sdks:
   dart: ">=3.0.2 <4.0.0"
   flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   swipe_cards: ^2.0.0+1
+  swipeable_card_stack: ^0.0.5
 
 
 dev_dependencies:


### PR DESCRIPTION
`swipeable_card_stack` package declaration in `pubspece.yaml` file is missing.
This causes other developers not to be able to run the code in `master` branch.

![Screenshot 2023-08-04 at 1 48 02 PM](https://github.com/Hamad-Anwar/Flutter-UI-Dev-Challange/assets/4591831/afa9f53f-7bd7-4b32-b2a4-b68b898ed6a0)
